### PR TITLE
Change lastntpconfigdate.rec path

### DIFF
--- a/app/ntpservice.go
+++ b/app/ntpservice.go
@@ -172,7 +172,7 @@ func (n ntpServer) SetNtpServer(ctx context.Context, serverList *v1.Ntp) (*empty
 	ntpSettingTime := currentTime.Format("2006.01.02 15:04:05")
 	log.Println("Ntp Last Setting Time : " + ntpSettingTime)
 
-	f, err := os.OpenFile("/opt/lastntpconfigdate.rec", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+	f, err := os.OpenFile("/etc/lastntpconfigdate.rec", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil {
 		log.Println("Error Opening file : ")
 	} else {

--- a/internal/ntpconfigurator/ntpconfigurator.go
+++ b/internal/ntpconfigurator/ntpconfigurator.go
@@ -42,7 +42,7 @@ const shell = "bash"
 const restartNtpService = "/usr/bin/systemctl restart ntp.service"
 const ntpDate = "ntpdate "
 const ntpConfigPath = "/etc/ntp.conf"
-const ntplastconfigPath = "/opt/lastntpconfigdate.rec"
+const ntplastconfigPath = "/etc/lastntpconfigdate.rec"
 const ntpCheckRunning = "/usr/bin/systemctl is-active --quiet ntp"
 const ntpCheckPeers = "ntpq -pn"
 


### PR DESCRIPTION
/opt is not the correct place to write the cache file. In some embedded system this folder can also be read-only.

Write to /etc instead