### PR TITLE
refactor: simplify chownSocket function and remove unnecessary else block

### DIFF
--- a/app/ntpservice.go
+++ b/app/ntpservice.go
@@ -73,14 +73,12 @@ func chownSocket(address string, userName string, groupName string) error {
 		err4 := os.Chown(address, uid, gid)
 		if err3 != nil || err4 != nil {
 			return errors.New("file permissions failed")
-		} else {
-			log.Println(uid, " : ", gid)
-			return nil
 		}
-
-	} else {
-		return errors.New("file permissions failed")
+		log.Println(uid, " : ", gid)
+		return nil
 	}
+
+	return errors.New("file permissions failed")
 }
 
 // StartGRPC Necessary actions are taken to start the GRPC server.


### PR DESCRIPTION
This PR simplifies the chownSocket function by removing the unnecessary else block and follows the conventional commit message format. The else block was redundant as the if block already contained a return statement. This change improves the code readability and reduces unnecessary nesting.

Changes:

- Removed else block in chownSocket function
- Simplified the code logic and improved readability

Please review and merge this PR.